### PR TITLE
Four tweaks as discussed via email

### DIFF
--- a/QueryServiceTest.py
+++ b/QueryServiceTest.py
@@ -558,6 +558,7 @@ class testQueryWebsockets(tools.TestBase):
                                                             version=curr_version)
                 expected_data_updated = copy.deepcopy(expected_data)
                 expected_data_updated["data"]["label"] = expected_data_updated["data"]["label"] + "_updated"
+                self.sample.bump_resource_version(expected_data_updated)
 
                 test_item = {
                     "ws_href": response["ws_href"],

--- a/RegistrationServiceTest.py
+++ b/RegistrationServiceTest.py
@@ -174,7 +174,10 @@ class testRegistrationAPIBasicResource(tools.TestBase):
 
             # Options
             with self.subTest(url=url):
-                self.options_request(url=url, expected_methods=["OPTIONS", "HEAD", "GET", "POST"])
+                expected_methods = ["OPTIONS", "GET", "POST"]
+                if defines.CHECK_HEAD_RESPONSE:
+                    expected_methods.append("HEAD")
+                self.options_request(url=url, expected_methods=expected_methods)
 
             # POST heartbeat
             self.post_request(url=url,

--- a/defines.py
+++ b/defines.py
@@ -22,9 +22,7 @@ SERVER_PORT = 8888
 VERSIONS = ["v1.2"]
 
 # Default CORS Headers
-CORS_HEADERS = ["Access-Control-Allow-Headers",
-                "Access-Control-Allow-Methods",
-                "Access-Control-Allow-Origin"]
+CORS_HEADERS = ["Access-Control-Allow-Origin"]
 
 # Wait time (s) between each request
 REQUEST_SLEEP = False
@@ -34,7 +32,7 @@ REQUEST_SLEEP_TIME = 0.005
 MDNS_WAIT_TIME = 2.0
 
 # Wait time (s) for garbage collection // missing heartbeat
-HEARTBEAT_TIMEOUT = 25.0
+HEARTBEAT_TIMEOUT = 15.0
 
 # Wait time (s) before checking WS messages after changes
 WAIT_WS_MSG = 1.0
@@ -51,8 +49,6 @@ CHECK_HEAD_RESPONSE = True
 HEAD_COMPARE_HEADERS = [
     "Content-Type",
     "Content-Length",
-    "Access-Control-Allow-Headers",
-    "Access-Control-Allow-Methods",
     "Access-Control-Allow-Origin",
     "Server",
 ]
@@ -63,7 +59,7 @@ RELAXED_TRAILING_SLASH_POLICY = False
 
 # # The following parameters should not be modified # #
 #  Which resources to test
-_RESOURCES = ["node", "device", "sender", "receiver", "source", "flow"]
+_RESOURCES = ["node", "device", "source", "flow", "sender", "receiver"]
 # Default URL snippets
 _BASE_URL = "{}://{}:{}".format(SERVER_PROTO, SERVER_IP, str(SERVER_PORT))
 _BASE_XNMOS_URL = _BASE_URL + "/x-nmos"

--- a/tools.py
+++ b/tools.py
@@ -352,6 +352,14 @@ class sample_data:
                                        expected_status_code=201,
                                        expected_json_response=data["data"])
 
+    def bump_resource_version(self, resource):
+        """Bump the version timestamp in the resource"""
+        v = [int(i) for i in resource["data"]["version"].split(':')]
+        v[1] += 1
+        if v[1] == 1e9:
+            v[0] += 1; v[1] = 0
+        resource["data"]["version"] = str(v[0]) + ':' + str(v[1])
+
     def update_sample_data(self, versions, resources):
         """Update sample resources of the given version"""
         for version in versions:
@@ -359,6 +367,7 @@ class sample_data:
                 url = "{}/{}/resource".format(defines._BASE_REGISTRATION_URL, version)
                 data = copy.deepcopy(self.get_sample_data(resource=resource, version=version))
                 data["data"]["label"] = data["data"]["label"] + "_updated"
+                self.bump_resource_version(data)
                 self.util.post_request(url=url,
                                        request_data=data,
                                        expected_status_code=200,


### PR DESCRIPTION
1. Fixed one unconditional expected "HEAD"
2. Removed CORS headers that are only required on preflight responses
4. Reordered resources so Senders are registered after Flows
5. Bumped resource version before updating the registrations